### PR TITLE
Fix setting text if NSTextField is non-existent

### DIFF
--- a/PyTouchBar/__init__.py
+++ b/PyTouchBar/__init__.py
@@ -219,6 +219,7 @@ class TouchBarItems:
 		
 		def __init__(self, **kwargs):
 			self.id = str(uuid.uuid4())
+			self.label = None
 			self.textBase = NSString(kwargs.get('text','Label'))
 			self.text_color_ = kwargs.get('text_color',Color.white)
 			self.alignment_ = kwargs.get('alignment',Alignment.center)
@@ -244,7 +245,8 @@ class TouchBarItems:
 			return self.label.stringValue()
 		
 		def textSetter(self, newValue):
-			self.label.setStringValue_(NSString(newValue))
+			if self.label:
+				self.label.setStringValue_(NSString(newValue))
 			
 		text = property(textGetter, textSetter)
 		


### PR DESCRIPTION
Python threw an AttributeError when I tried to set text:

```
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.8/3.8.3/Frameworks/Python.framework/Versions/3.8/lib/python3.8/tkinter/__init__.py", line 1883, in __call__
    return self.func(*args)
  File "/usr/local/Cellar/python@3.8/3.8.3/Frameworks/Python.framework/Versions/3.8/lib/python3.8/tkinter/__init__.py", line 804, in callit
    func(*args)
  File "/Users/notimportant/dev/playground/main.py", line 32, in create_touch_bar
    self.tb_label.text = str(time.time())
  File "/usr/local/lib/python3.8/site-packages/PyTouchBar/__init__.py", line 198, in textSetter
    self.label.setStringValue_(NSString(newValue))
AttributeError: 'Label' object has no attribute 'label'
```

I editted the setter so it checks whether the Label instance has a `label` attribute.